### PR TITLE
Replace old hardcoded OG image with a dynamic branded preview

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,10 +4,39 @@ import { Analytics } from "@vercel/analytics/react";
 
 const inter = Inter({ subsets: ["latin"] });
 
+const title = "Time Since — your club won a real trophy";
+const description =
+  "A live count-up of how long it's been since football clubs last won a real trophy — the league or the Champions League. The FA Cup doesn't count.";
+
+// Resolve the canonical site URL: explicit override → Vercel production domain →
+// Vercel deployment (preview) URL → localhost. Used to make the OG image URL
+// absolute so WhatsApp/social fetch the right preview.
+const siteUrl =
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  (process.env.VERCEL_PROJECT_PRODUCTION_URL
+    ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
+    : process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : "http://localhost:3000");
+
 export const metadata = {
-  title: "Time Since — your club won a real trophy",
-  description:
-    "A live count-up of how long it's been since football clubs last won a real trophy — the league or the Champions League. The FA Cup doesn't count.",
+  metadataBase: new URL(siteUrl),
+  title,
+  description,
+  // og:image / twitter:image are wired up automatically from app/opengraph-image.tsx
+  openGraph: {
+    title,
+    description,
+    url: "/",
+    siteName: "Time Since",
+    type: "website",
+    locale: "en_GB",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+  },
 };
 
 export default function RootLayout({
@@ -17,12 +46,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <meta
-          property="og:image"
-          content="https://storage.googleapis.com/flyweight-cdn/timesince_screenshotV1.png"
-        />
-      </head>
       <body className={inter.className}>
         {children}
         <Analytics />

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,77 @@
+import { ImageResponse } from "next/server";
+
+// Dynamically generated social preview image (1200x630).
+// Replaces the old hardcoded V1 screenshot. Served at /opengraph-image.
+export const runtime = "edge";
+export const alt = "Time Since — your club won a real trophy";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "linear-gradient(150deg, #EF0107 0%, #7a0c0c 100%)",
+          color: "#ffffff",
+          fontFamily: "sans-serif",
+          padding: "80px",
+          textAlign: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 28,
+            letterSpacing: 8,
+            textTransform: "uppercase",
+            opacity: 0.85,
+          }}
+        >
+          ⏱  Time Since
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 108,
+            fontWeight: 900,
+            lineHeight: 1.05,
+            marginTop: 18,
+          }}
+        >
+          Time Since
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 56,
+            fontWeight: 700,
+            marginTop: 8,
+            opacity: 0.95,
+          }}
+        >
+          your club won a real trophy
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 30,
+            marginTop: 40,
+            padding: "14px 28px",
+            borderRadius: 999,
+            background: "rgba(0,0,0,0.25)",
+          }}
+        >
+          Only the league &amp; the Champions League count. The FA Cup doesn&apos;t.
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
The social preview still pointed at the V1 screenshot on a Google CDN, so WhatsApp/social showed the old image.

- Generate a fresh 1200x630 branded preview via app/opengraph-image.tsx (next/server ImageResponse, edge runtime)
- Move to the Metadata API with metadataBase (resolves canonical prod URL, Vercel preview URL, or localhost) so og:image is absolute
- Add OpenGraph + Twitter (summary_large_image) metadata
- Drop the manual <head> og:image tag